### PR TITLE
fix: avoid `apt-get` when possible

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
       shell: bash
       id: betagouv
       run: |
-        sudo apt-get install -y jq wget
+        if [ ! -x "$(command -v jq)" ]; then sudo apt-get install -y jq; fi
+        if [ ! -x "$(command -v wget)" ]; then sudo apt-get install -y wget; fi
         wget -O - ${{ inputs.api_url }} | jq '.data[] | select(.id == "${{ inputs.id }}")' > ${{ inputs.output }}
 
         stats_url=$( cat ${{ inputs.output }} | jq -r ".attributes.stats_url" )


### PR DESCRIPTION
Permettrait d'utiliser cette action dans un environnement sans accès root mais où les dépendances de base comme `wget` et `yq` sont préinstallées.